### PR TITLE
docs: add PowerShell compatibility warnings for command chaining

### DIFF
--- a/HOW_TO_OPEN_APP.md
+++ b/HOW_TO_OPEN_APP.md
@@ -1,0 +1,101 @@
+# 🚀 How to Open This App
+
+**Quick reference for opening Chen's Engineer Toolbox**
+
+---
+
+## ⚡ Quick Start (2 Terminals Required)
+
+### Terminal 1: Start Backend
+```bash
+python -m uvicorn backend.main:app --reload
+```
+✅ Backend runs at: **http://localhost:8000**
+
+### Terminal 2: Start Frontend
+```bash
+# macOS/Linux/Git Bash:
+cd frontend && python -m streamlit run Home.py
+
+# PowerShell (Windows):
+cd frontend; python -m streamlit run Home.py
+```
+✅ Frontend opens at: **http://localhost:8501**
+
+> ⚠️ **PowerShell Users**: Use semicolon `;` instead of `&&` to chain commands. PowerShell does not support the `&&` operator.
+
+---
+
+## 🪟 Windows Users - Using Batch Files
+
+**Double-click or run:**
+1. `run_backend.bat` (Terminal 1)
+2. `run_frontend.bat` (Terminal 2)
+
+---
+
+## 🍎 Mac/Linux Users - Using Shell Scripts
+
+**Run in terminal:**
+```bash
+./run_backend.sh    # Terminal 1
+./run_frontend.sh   # Terminal 2
+```
+
+---
+
+## ❗ Common Errors & Fixes
+
+### "uvicorn is not recognized"
+```bash
+pip install uvicorn fastapi
+```
+
+### "streamlit is not recognized"
+```bash
+pip install streamlit
+```
+
+### "No module named 'backend'"
+- Make sure you're in the **project root** directory
+- Check: You should see both `backend/` and `frontend/` folders
+
+### "Backend API is not available" (in frontend)
+- Make sure **backend is running** in Terminal 1
+- Check http://localhost:8000/health in your browser
+
+### Port already in use
+- Close other apps using ports 8000 or 8501
+- Or change backend port: `python -m uvicorn backend.main:app --reload --port 8001`
+
+---
+
+## 📦 First Time Setup
+
+If you haven't installed dependencies yet:
+```bash
+pip install -r requirements.txt
+```
+
+---
+
+## 📍 What You'll See
+
+Once both are running, open **http://localhost:8501** in your browser:
+
+```
+Sidebar Navigation:
+├─ 🏠 Home
+├─ 📊 Dashboard
+├─ 🏭 Facility ▶️ (click to expand)
+│   └─ ⚙️ TML Data Loader
+└─ 🛢️ Pipeline ▶️ (click to expand)
+    └─ 📊 ILI Visual Tool
+```
+
+---
+
+## 📚 Need More Help?
+
+See **[QUICK_START.md](QUICK_START.md)** for detailed instructions and troubleshooting.
+

--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -2,114 +2,165 @@
 
 Get Chen's Engineer Toolbox up and running in 3 steps!
 
+## Prerequisites
+
+- **Python 3.11+** installed and added to PATH
+- Verify: `python --version` should show 3.11 or higher
+
 ## Step 1: Install Dependencies
 
-Choose your preferred method:
-
-### Option A: Using uv (Recommended - Faster!)
+**From the project root directory**, run:
 
 ```bash
-# Install uv (if not already installed)
-curl -LsSf https://astral.sh/uv/install.sh | sh
-
-# Or on Windows with PowerShell:
-powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
-
-# Install project dependencies
-uv sync
+pip install -r requirements.txt
 ```
 
-### Option B: Using pip
-
+**Optional - Install development tools:**
 ```bash
-# Create and activate virtual environment
+pip install -r requirements-dev.txt
+```
+
+**Alternative - Using virtual environment (recommended):**
+```bash
+# Create virtual environment
 python -m venv venv
 
+# Activate it:
 # Windows:
 venv\Scripts\activate
-
 # macOS/Linux:
 source venv/bin/activate
 
 # Install dependencies
 pip install -r requirements.txt
-# Or with dev dependencies:
-pip install -e ".[dev]"
 ```
 
 ## Step 2: Start the Backend
 
-Open a terminal and run:
+Open a terminal **in the project root directory** and run:
 
-**Windows:**
+**Windows (using batch file):**
 ```bash
 run_backend.bat
 ```
 
-**macOS/Linux:**
+**macOS/Linux (using shell script):**
 ```bash
 ./run_backend.sh
 ```
 
-**Or manually:**
+**Or manually (works on all platforms):**
 ```bash
-uv run uvicorn backend.main:app --reload
+python -m uvicorn backend.main:app --reload
 ```
 
-✅ Backend will start at: http://127.0.0.1:8000  
-📚 API docs available at: http://127.0.0.1:8000/docs
+✅ Backend will start at: **http://localhost:8000**  
+📚 API docs available at: **http://localhost:8000/docs**
+
+**Keep this terminal window open!**
+
+---
 
 ## Step 3: Start the Frontend
 
-Open a **second terminal** and run:
+Open a **second terminal** (keep the backend running) and run:
 
-**Windows:**
+**Windows (using batch file):**
 ```bash
 run_frontend.bat
 ```
 
-**macOS/Linux:**
+**macOS/Linux (using shell script):**
 ```bash
 ./run_frontend.sh
 ```
 
 **Or manually:**
 ```bash
-uv run streamlit run frontend/Home.py
+# macOS/Linux/Git Bash:
+cd frontend && python -m streamlit run Home.py
+
+# PowerShell (Windows):
+cd frontend; python -m streamlit run Home.py
 ```
 
-✅ Frontend will open automatically in your browser at: http://localhost:8501
+> ⚠️ **PowerShell Note**: Use semicolon `;` instead of `&&` to chain commands in PowerShell. The `&&` operator is not supported in PowerShell.
+
+✅ Frontend will open automatically in your browser at: **http://localhost:8501**
+
+**If it doesn't open automatically, manually navigate to http://localhost:8501**
 
 ## 🎉 You're Ready!
 
 Navigate through the sidebar:
-- **Home**: Welcome page
-- **Dashboard**: Project overview
-- **Facility**: Facility tools (coming soon)
-- **Pipeline → ILI Visual Tool**: Upload and analyze Excel files!
+- **🏠 Home**: Welcome page
+- **📊 Dashboard**: Project overview
+- **🏭 Facility** (expandable): Click to expand and see:
+  - **⚙️ TML Data Loader**: Process thickness monitoring location data
+- **🛢️ Pipeline** (expandable): Click to expand and see:
+  - **📊 ILI Visual Tool**: Upload and analyze in-line inspection Excel files
 
-## 📝 Testing the ILI Tool
+## 📝 Testing the Tools
 
-1. Navigate to **Pipeline → ILI Visual Tool**
-2. Upload an Excel file with numeric data
-3. Preview the file structure
-4. Map columns (distance, depth, metal loss)
-5. Process and view visualizations!
+### ILI Visual Tool (Pipeline Inspection)
+1. Click **🛢️ Pipeline** in the sidebar to expand
+2. Click **📊 ILI Visual Tool**
+3. Upload an Excel file with numeric data
+4. Click "Preview" to see file structure
+5. Select sheet and map columns (distance, depth, metal loss)
+6. Click "Process Data" and view visualizations!
+
+### TML Data Loader (Facility Management)
+1. Click **🏭 Facility** in the sidebar to expand
+2. Click **⚙️ TML Data Loader**
+3. Upload source Excel file and template file
+4. Select workflows to process (up to 20 available)
+5. Click "Process TML Data"
+6. Download the generated ZIP file with results
 
 ## 🆘 Troubleshooting
 
 ### Backend not starting?
-- Make sure port 8000 is not in use
-- Check that all dependencies are installed
-- Verify Python 3.11+ is installed: `python --version`
 
-### Frontend not connecting to backend?
-- Ensure backend is running first
-- Check the backend URL in frontend (default: http://127.0.0.1:8000)
+**"uvicorn is not recognized" or "No module named uvicorn":**
+```bash
+pip install uvicorn fastapi
+```
+
+**Port 8000 already in use:**
+- Find and close the other application using port 8000
+- Or change the port: `python -m uvicorn backend.main:app --reload --port 8001`
+
+**"No module named 'backend'":**
+- Make sure you're in the project root directory (not inside backend/ or frontend/)
+- Check: `dir` (Windows) or `ls` (Mac/Linux) should show both `backend/` and `frontend/` folders
+
+### Frontend not starting?
+
+**"streamlit is not recognized" or "No module named streamlit":**
+```bash
+pip install streamlit
+```
+
+**"Cannot connect to backend" or "Backend API is not available":**
+- Ensure the backend is running in a separate terminal
+- Check that backend shows no errors
+- Verify backend is at http://localhost:8000 (try opening in browser)
 
 ### Import errors?
-- Reinstall dependencies: `uv sync` or `pip install -r requirements.txt`
+- Reinstall dependencies: `pip install -r requirements.txt`
 - Make sure you're in the project root directory
+- Try with a fresh virtual environment
+
+### Both terminals close immediately?
+- Run commands directly in PowerShell/Command Prompt, not by double-clicking
+- Or right-click the .bat file → "Run as Administrator"
+
+### "The token '&&' is not a valid statement separator" error?
+- **This is a PowerShell issue!** PowerShell doesn't support the `&&` operator
+- **Solution**: Use semicolon `;` instead of `&&` to chain commands
+- Example: `cd frontend; python -m streamlit run Home.py`
+- Alternatively: Use the provided `.bat` files which handle this automatically
 
 ## 📖 Next Steps
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ streamlit run frontend/Home.py
 
 The frontend will open automatically in your browser at `http://localhost:8501`
 
+> ⚠️ **PowerShell Users**: When running commands manually with `cd`, use semicolon `;` instead of `&&` to chain commands (e.g., `cd frontend; python -m streamlit run Home.py`). PowerShell does not support the `&&` operator.
+
 ## 🛠️ API Endpoints
 
 ### Backend API

--- a/run_backend.bat
+++ b/run_backend.bat
@@ -3,12 +3,21 @@
 echo Starting Chen's Engineer Toolbox - Backend API
 echo ==============================================
 echo.
+echo Starting backend at http://localhost:8000
+echo API docs will be at http://localhost:8000/docs
+echo.
 
-where uv >nul 2>nul
-if %ERRORLEVEL% EQU 0 (
-    echo Using uv to run backend...
-    uv run uvicorn backend.main:app --reload
-) else (
-    echo Using uvicorn directly...
-    uvicorn backend.main:app --reload
+cd /d "%~dp0"
+python -m uvicorn backend.main:app --reload
+
+if %ERRORLEVEL% NEQ 0 (
+    echo.
+    echo ERROR: Failed to start backend!
+    echo.
+    echo Please ensure:
+    echo   1. Python 3.11+ is installed: python --version
+    echo   2. Dependencies are installed: pip install -r requirements.txt
+    echo   3. You are in the project root directory
+    echo.
+    pause
 ) 

--- a/run_backend.sh
+++ b/run_backend.sh
@@ -3,12 +3,25 @@
 echo "Starting Chen's Engineer Toolbox - Backend API"
 echo "=============================================="
 echo ""
+echo "Starting backend at http://localhost:8000"
+echo "API docs will be at http://localhost:8000/docs"
+echo ""
 
-# Check if uv is available
-if command -v uv &> /dev/null; then
-    echo "Using uv to run backend..."
-    uv run uvicorn backend.main:app --reload
-else
-    echo "Using uvicorn directly..."
-    uvicorn backend.main:app --reload
+# Change to script directory
+cd "$(dirname "$0")"
+
+# Run backend using python -m (more reliable)
+python -m uvicorn backend.main:app --reload
+
+# Check if command failed
+if [ $? -ne 0 ]; then
+    echo ""
+    echo "ERROR: Failed to start backend!"
+    echo ""
+    echo "Please ensure:"
+    echo "  1. Python 3.11+ is installed: python --version"
+    echo "  2. Dependencies are installed: pip install -r requirements.txt"
+    echo "  3. You are in the project root directory"
+    echo ""
+    read -p "Press Enter to exit..."
 fi 

--- a/run_frontend.bat
+++ b/run_frontend.bat
@@ -3,12 +3,21 @@
 echo Starting Chen's Engineer Toolbox - Frontend UI
 echo ==============================================
 echo.
+echo Starting frontend at http://localhost:8501
+echo The app will open automatically in your browser
+echo.
 
-where uv >nul 2>nul
-if %ERRORLEVEL% EQU 0 (
-    echo Using uv to run frontend...
-    uv run streamlit run frontend/Home.py
-) else (
-    echo Using streamlit directly...
-    streamlit run frontend/Home.py
+cd /d "%~dp0\frontend"
+python -m streamlit run Home.py
+
+if %ERRORLEVEL% NEQ 0 (
+    echo.
+    echo ERROR: Failed to start frontend!
+    echo.
+    echo Please ensure:
+    echo   1. Python 3.11+ is installed: python --version
+    echo   2. Streamlit is installed: pip install streamlit
+    echo   3. You are in the project root directory
+    echo.
+    pause
 ) 

--- a/run_frontend.sh
+++ b/run_frontend.sh
@@ -3,12 +3,25 @@
 echo "Starting Chen's Engineer Toolbox - Frontend UI"
 echo "=============================================="
 echo ""
+echo "Starting frontend at http://localhost:8501"
+echo "The app will open automatically in your browser"
+echo ""
 
-# Check if uv is available
-if command -v uv &> /dev/null; then
-    echo "Using uv to run frontend..."
-    uv run streamlit run frontend/Home.py
-else
-    echo "Using streamlit directly..."
-    streamlit run frontend/Home.py
+# Change to script directory, then to frontend
+cd "$(dirname "$0")/frontend"
+
+# Run frontend using python -m (more reliable)
+python -m streamlit run Home.py
+
+# Check if command failed
+if [ $? -ne 0 ]; then
+    echo ""
+    echo "ERROR: Failed to start frontend!"
+    echo ""
+    echo "Please ensure:"
+    echo "  1. Python 3.11+ is installed: python --version"
+    echo "  2. Streamlit is installed: pip install streamlit"
+    echo "  3. You are in the project root directory"
+    echo ""
+    read -p "Press Enter to exit..."
 fi 


### PR DESCRIPTION
- Add PowerShell-specific command examples using semicolon (;) instead of &&
- Update README.md, QUICK_START.md, and HOW_TO_OPEN_APP.md with platform-specific instructions
- Add troubleshooting entry for '&&' token error in PowerShell
- Clarify that PowerShell does not support && operator for chaining commands
- Provide examples for both Unix-like shells and PowerShell

Fixes issue where Windows PowerShell users encountered parse errors when following documentation that used && to chain commands.